### PR TITLE
enable Sentry only if not DEBUG

### DIFF
--- a/foreign/settings.py
+++ b/foreign/settings.py
@@ -128,7 +128,6 @@ INSTALLED_APPS = (
     # 'compressor',
     'gunicorn',
     'dryrub',
-    'raven.contrib.django.raven_compat',
     # Uncomment the next line to enable the admin:
     # 'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:
@@ -168,3 +167,6 @@ LOGGING = {
 }
 
 from herokal.settings import *
+
+if not DEBUG:
+    INSTALLED_APPS += ('raven.contrib.django.raven_compat',)


### PR DESCRIPTION
This will prevent Sentry from firing when errors are encountered in development.
